### PR TITLE
feat: add footer styling to mobile view

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,14 +1,14 @@
-body{
-  background: linear-gradient(to right,#0a0714,#290062,#612397); 
+body {
+  background: linear-gradient(to right, #0a0714, #290062, #612397);
   background-size: cover;
   padding: 0;
   margin: 0;
 }
 .custom-bg-color {
-  background-color: rgba(24, 24, 24, 0.986); 
+  background-color: rgba(24, 24, 24, 0.986);
 }
 
-.row{
+.row {
   width: 100%;
   height: auto;
   padding: 9px;
@@ -16,19 +16,18 @@ body{
   margin: 10px 0;
 }
 
-.card{
-  border: 3.9px solid #111; 
+.card {
+  border: 3.9px solid #111;
   border-radius: 8px;
 }
 
-.navbar-brand{
-margin-left: 3rem;
-
+.navbar-brand {
+  margin-left: 3rem;
 }
-.card-text{
+.card-text {
   text-align: justify;
 }
-.linguagens{
+.linguagens {
   margin-left: 1rem;
   color: rgba(255, 255, 255, 0.89);
   font-weight: bold;
@@ -36,105 +35,122 @@ margin-left: 3rem;
   text-shadow: 2px 2px 4px #7d144c;
 }
 
-.card{
+.card {
   background-color: #222;
   color: #fff;
 }
 .orien {
   text-align: center;
   font-weight: bold;
-  color: #ffffffe8; 
-  box-shadow: 8px 6px 4px rgba(0, 0, 0, 0.5); 
-  filter: drop-shadow(6px 8px 8px #d016ffee); 
-  border: 4px solid #240033; 
+  color: #ffffffe8;
+  box-shadow: 8px 6px 4px rgba(0, 0, 0, 0.5);
+  filter: drop-shadow(6px 8px 8px #d016ffee);
+  border: 4px solid #240033;
   margin: 10px;
   border-radius: 9px;
-  background:  linear-gradient(45deg, rgb(0, 0, 0), transparent);
+  background: linear-gradient(45deg, rgb(0, 0, 0), transparent);
   font-size: 39.3px;
 }
 
-
-
-.nav-item{
+.nav-item {
   padding: 5px;
 }
 
-.navbar-text{
+.navbar-text {
   margin-right: 10px;
 }
 
-
 /* footer */
 
-body{
-  margin:0;
-  overflow-x:hidden;
-  }
-  
-  .footer{
-  background:#000;
-  padding:30px 0px;
-  font-family: 'Play', sans-serif;
-  text-align:center;
-  }
-  
-  .footer .rowend{
-  width:100%;
-  margin:1% 0%;
-  padding:0.6% 0%;
-  color:gray;
-  font-size:0.8em;
+body {
+  margin: 0;
+  overflow-x: hidden;
+}
+
+.footer {
+  background: #000;
+  padding: 30px 0px;
+  font-family: "Play", sans-serif;
+  text-align: center;
+}
+
+.footer .rowend {
+  width: 100%;
+  margin: 1% 0%;
+  padding: 0.6% 0%;
+  color: gray;
+  font-size: 0.8em;
   font-size: 14px;
+}
+
+.footer .rowend a {
+  text-decoration: none;
+  color: gray;
+  transition: 0.5s;
+}
+
+.footer .rowend a:hover {
+  color: #fff;
+}
+
+.footer .rowend ul {
+  width: 100%;
+}
+
+.footer .rowend ul li {
+  display: inline-block;
+  margin: 0px 30px;
+}
+
+.footer .rowend a i {
+  font-size: 2em;
+  margin: 0% 1%;
+}
+.emailpessoal {
+  color: grey;
+  font-size: 14px;
+}
+
+@media (max-width: 720px) {
+  .footer {
+    text-align: left;
+    padding: 5%;
   }
-  
-  .footer .rowend a{
-  text-decoration:none;
-  color:gray;
-  transition:0.5s;
+  .footer .rowend ul li {
+    display: block;
+    margin: 10px 0px;
+    text-align: left;
   }
-  
-  .footer .rowend a:hover{
-  color:#fff;
+  .footer .rowend a i {
+    margin: 0% 3%;
   }
-  
-  .footer .rowend ul{
-  width:100%;
-  }
-  
-  .footer .rowend ul li{
-  display:inline-block;
-  margin:0px 30px;
-  }
-  
-  .footer .rowend a i{
-  font-size:2em;
-  margin:0% 1%;
-  }
-  .emailpessoal{
-    color: grey;
-    font-size: 14px;
-  }
-  
-  @media (max-width:720px){
-  .footer{
-  text-align:left;
-  padding:5%;
-  }
-  .footer .rowend ul li{
-  display:block;
-  margin:10px 0px;
-  text-align:left;
-  }
-  .footer .rowend a i{
-  margin:0% 3%;
-  }
-  .card-body{
+  .card-body {
     align-items: center;
   }
-  .row{
+  .row {
     margin: 10px 0;
   }
-
-  }
+}
 
 /* feito por Carlos Gabriel J. I. Santos */
+
+@media (max-width: 568px) {
+  .footer {
+    padding: 0;
+  }
+
+  .footer .rowend:first-child {
+    padding-top: 16px;
+  }
+
+  .footer .rowend {
+    text-align: center;
+  }
+
+  .footer .rowend ul {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-left: 0;
+  }
+}


### PR DESCRIPTION
In this commit I have formatted the main.css with the prettier (VScode extension).
But mainly I have included styling to your footer when on a really small mobile device.
Here's how it looks:

![image](https://github.com/Inojoza28/WAI/assets/72167417/1812c3a6-ad5e-4446-94a9-d18829ed10b7)

You can review it, try it on your local before merging this PR. You can even make changes to it if you feel like a couple ticks are needed.